### PR TITLE
Improve documentation and bug fix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,8 @@ for this purpose.
 
 ### Format the code
 
+Presubmit will fail if the code is not properly format.
+
 #### Rust
 
 Nightly features in `rustfmt` is used, so run `cargo +nightly fmt` to format the entire project.
@@ -55,6 +57,8 @@ python -m ruff check . --fix
 
 ### Regenerate code
 
+Files named `generated.rs` are generated files. One should avoid manually editting the files. Presubmit will fail if the generated files are not sync with the source.
+
 1. Install LLVM and set up the environment variable required by `bindgen`: [link](https://rust-lang.github.io/rust-bindgen/requirements.html), because `bindgen` is used in the codegen process.
 
 2. Make sure python newer than 3.9 is installed.
@@ -71,18 +75,53 @@ The codegen scripts will automatically format the generated file, so no need to 
 
 Files are generated in different mechanism:
 
-* `vulkan-layer/src/bindings/generated/vk_layer_bindings.rs`
+* `vulkan-layer/src/bindings/vk_layer/generated.rs`
 
   This file is generated from `vk_layer.h` in the `Vulkan-Headers` dependency by using `bindgen`.
 
-* `vulkan-layer/src/generated/{layer_trait,global_simple_intercept}.rs`
+* `vulkan-layer/src/{layer_trait,global_simple_intercept}/generated.rs`
 
   These 2 files are generated through the `scritps/vulkan_layer_genvk.py`. This script utilizes the `OutputGenerator` class defined in the `generator.py` from the Vulkan registry repo.
 
 ### Test
 
+All tests mentioned are run in CI. Miri tests are run as a post submit because of the slowness while others are presubmit.
+
+#### Unit tests and integration tests
+
 `cargo-nextest` is the recommended way to run the test.  Run `cargo nextest run` to run all tests. This is how CI runs the tests. All tests are supposed to only run in a separate process.
 
 Vanilla `cargo test` is not supported, because that will run tests in the same binary in the same process. However, `cargo +nightly test -Z panic-abort-tests` is Ok because it will [allow subprocess testing](https://github.com/rust-lang/rust/issues/67650). In addition, the library is supposed to be built with `panic="abort"`.
 
+#### Documentation tests
+
+```bash
+cargo +nightly test --doc --all-features --workspace -- --show-output
+```
+
+#### Coverage
+
+Code coverage is also part of the CI. Changes shouldn't cause the coverage to drop. Newly added functions or modules are expected high test coverage.
+
 [`cargo-llvm-cov`](https://github.com/taiki-e/cargo-llvm-cov) [with `cargo-nextest`](https://nexte.st/book/test-coverage.html#llvm-cov) is used to generate the code coverage info. To generate the `lcov` coverage file locally under `target/lcov.info`, run `cargo llvm-cov nextest --lcov --output-path target/lcov.info`.
+
+#### Miri tests
+
+When writing unsafe code or changing the "trivially-destructible" behavior of the global resources, Miri tests should be used to catch undefined behaviors and resource leak. It is recommended to run Miri tests on Linux. Follow [these steps](https://github.com/rust-lang/miri#using-miri) to install Miri. Use the following command to run the Miri test on Linux:
+
+```bash
+MIRIFLAGS="-Zmiri-tree-borrows" cargo +nightly miri nextest run --all-targets --all-features -j8 --no-fail-fast
+```
+
+Miri tests are usually very slow, use the [test filter](https://nexte.st/book/filter-expressions.html) to run a specific test.
+
+```bash
+MIRIFLAGS="-Zmiri-tree-borrows" cargo +nightly miri nextest run --all-targets --all-features --no-fail-fast -E'test(test_should_return_fp_when_called_with_get_instance_proc_addr_name)'
+```
+
+### Document
+
+All public intefaces must have documents. Otherwise the presubmit will fail. After a new PR is merged, the document will be automatically regenerated and published. Use the badge in [`README.md`](README.md) to browse the document. To generate the document locally, run
+```bash
+cargo +nightly doc --workspace --all-features --no-deps --open
+```

--- a/README.md
+++ b/README.md
@@ -57,15 +57,13 @@ TODO
 
 ## TODO
 
-- [x] Allow interception of `vkGet*ProcAddr` will fix this issue. Handle the case where the underlying driver returns a null pointer to function. Currently we still return a valid function pointer, however the Android loader may test the returned function pointer to decide if such function is supported.
 - [x] Set up `Android.bp` to build in an Android tree.
   - [ ] Upgrade ash in aosp, and remove vulkano, so that we can build from aosp/master.
 - [x] Auto-generate the binding from [`vk_layer.h`](https://github.com/KhronosGroup/Vulkan-Headers/blob/9e61870ecbd32514113b467e0a0c46f60ed222c7/include/vulkan/vk_layer.h).
-- [x] Auto-generate the `global_simple_intercept.rs` from `vk.xml`.
-- [x] Auto-generate the `layer_trait.rs` file from `vk.xml`.
-- [x] Use a attribute macro to track which function is implemented in the `LayerTrait`, and don't inject all other functions for performance.
-- [ ] Make global instance trivially destructible after all instances are destroyed. We can't rely on the destructor of DLL to perform clean up. We need to require the user to declare the global static, and declare one for each layer. User's `Layer` global instance will also be created before the first `vkCreateInstance` is returned and will be destroyed after the last `vkDestroyInstance` is called.
-- [ ] Use procedure macro to generate the export functions in `lib.rs` file for the layer user.
+- [x] Auto-generate the `Layer` trait and the interception code from `vk.xml`.
+- [x] Use an attribute macro to track which function is implemented in the `Layer` trait, and don't inject all other functions for performance.
+- [x] Make global instance trivially destructible after all instances are destroyed, so the layer is robust against the situation where the dynamic library is loaded and unloaded for several times.
+- [x] Use procedure macro to generate the export functions in `lib.rs` file for the layer user.
 - [ ] Use the xtask workflow to generate the layer json file.
 - [ ] Support the latest layer interface version. Currently 2 is the latest version. e.g. correctly handle the `vk_layerGetPhysicalDeviceProcAddr` case.
 - [ ] Allow intercepting [pre-instance functions](https://github.com/KhronosGroup/Vulkan-Loader/blob/0c63db1aeda6916690b863688fa6cdf2ac1f790b/docs/LoaderLayerInterface.md#pre-instance-functions).

--- a/vulkan-layer-macros/src/lib.rs
+++ b/vulkan-layer-macros/src/lib.rs
@@ -255,7 +255,7 @@ pub fn auto_deviceinfo_impl(_: TokenStream, item: TokenStream) -> TokenStream {
 /// #         Default::default()
 /// #     }
 /// #
-/// #     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+/// #     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
 /// #         &self.0
 /// #     }
 /// #

--- a/vulkan-layer/src/layer_trait.rs
+++ b/vulkan-layer/src/layer_trait.rs
@@ -226,7 +226,7 @@ pub trait DeviceInfo: Send + Sync {
     /// #         Default::default()
     /// #     }
     /// #
-    /// #     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+    /// #     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
     /// #         &self.0
     /// #     }
     /// #
@@ -481,7 +481,7 @@ pub trait InstanceInfo: Send + Sync {
     /// #         Default::default()
     /// #     }
     /// #
-    /// #     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+    /// #     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
     /// #         &self.0
     /// #     }
     ///
@@ -1013,7 +1013,7 @@ pub struct LayerManifest {
 ///         manifest
 ///     }
 ///
-///     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+///     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
 ///         &self.0
 ///     }
 ///
@@ -1079,7 +1079,7 @@ pub struct LayerManifest {
 ///         manifest
 ///     }
 ///
-///     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+///     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
 ///         &self.0
 ///     }
 ///
@@ -1189,7 +1189,7 @@ pub trait Layer: Sync + Default + 'static {
     /// #         Default::default()
     /// #     }
     /// #
-    /// #     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+    /// #     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
     /// #         &self.0
     /// #     }
     /// #
@@ -1255,7 +1255,7 @@ pub trait Layer: Sync + Default + 'static {
     /// #         Default::default()
     /// #     }
     /// #
-    /// #     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+    /// #     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
     /// #         &self.0
     /// #     }
     /// #
@@ -1331,7 +1331,7 @@ pub trait Layer: Sync + Default + 'static {
     /// #         manifest
     /// #     }
     /// #
-    /// #     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+    /// #     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
     /// #         &self.0
     /// #     }
     /// #
@@ -1361,14 +1361,14 @@ pub trait Layer: Sync + Default + 'static {
     fn global_instance() -> &'static Global<Self>;
 
     /// Returns a reference of the underlying [`GlobalHooksInfo`] object.
-    fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo;
+    fn global_hooks_info(&self) -> &Self::GlobalHooksInfo;
 
     /// Returns a reference of the underlying [`GlobalHooks`] object.
     ///
     /// The layer framework relies on this function to obtain [`GlobalHooks`], and implementors
     /// should avoid overriding this method.
-    fn get_global_hooks(&self) -> <Self::GlobalHooksInfo as GlobalHooksInfo>::HooksRefType<'_> {
-        self.get_global_hooks_info().hooks()
+    fn global_hooks(&self) -> <Self::GlobalHooksInfo as GlobalHooksInfo>::HooksRefType<'_> {
+        self.global_hooks_info().hooks()
     }
 
     /// The factory method for the [`InstanceInfo`] type.
@@ -1503,7 +1503,7 @@ pub trait Layer: Sync + Default + 'static {
     /// #         Default::default()
     /// #     }
     /// #
-    /// #     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+    /// #     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
     /// #         &self.0
     /// #     }
     ///
@@ -1654,7 +1654,7 @@ pub trait Layer: Sync + Default + 'static {
     /// #         Default::default()
     /// #     }
     /// #
-    /// #     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+    /// #     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
     /// #         &self.0
     /// #     }
     /// #

--- a/vulkan-layer/src/lib.rs
+++ b/vulkan-layer/src/lib.rs
@@ -85,7 +85,7 @@
 //!         Default::default()
 //!     }
 //!
-//!     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+//!     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
 //!         &self.0
 //!     }
 //!
@@ -206,7 +206,7 @@
 //!         manifest
 //!     }
 //!
-//!     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+//!     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
 //!         &self.0
 //!     }
 //!
@@ -267,7 +267,7 @@
 //! #         manifest
 //! #     }
 //! #
-//! #     fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+//! #     fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
 //! #         &self.0
 //! #     }
 //! #
@@ -683,7 +683,7 @@ impl<T: Layer> Global<T> {
             .iter()
             .any(|command| *command == LayerVulkanCommand::CreateInstance);
         let layer_result = if hooked {
-            global.layer_info.get_global_hooks().create_instance(
+            global.layer_info.global_hooks().create_instance(
                 unsafe { create_info.as_ref() }.unwrap(),
                 layer_info,
                 unsafe { allocator.as_ref() },
@@ -1642,7 +1642,7 @@ mod test {
                 LayerManifest::test_default()
             }
 
-            fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+            fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
                 &self.0
             }
 

--- a/vulkan-layer/src/lib.rs
+++ b/vulkan-layer/src/lib.rs
@@ -1325,7 +1325,8 @@ impl<T: Layer> Global<T> {
     ///
     ///    If the layer implementation intercepts the `vkGetInstanceProcAddr` function(i.e.
     ///    [`Layer::hooked_instance_commands`] returns `vkGetInstanceProcAddr`), the layer framework
-    ///    just calls [`InstanceHooks::get_instance_proc_addr`] and return the return value.
+    ///    just calls [`InstanceHooks::get_instance_proc_addr`] and return the return value if
+    ///    [`LayerResult::Handled`] is returned.
     ///
     ///    Otherwise, the layer framework handles most of the logic according to
     ///    [`Layer::hooked_instance_commands`] and [`Layer::hooked_device_commands`]:

--- a/vulkan-layer/src/test_utils.rs
+++ b/vulkan-layer/src/test_utils.rs
@@ -346,7 +346,7 @@ impl<T: TestLayerTag> Layer for TestLayer<T> {
         MockTestLayer::<T>::mock().manifest()
     }
 
-    fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+    fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
         &self.global_hooks_info
     }
 

--- a/vulkan-layer/tests/autoinfo_macros_test.rs
+++ b/vulkan-layer/tests/autoinfo_macros_test.rs
@@ -59,7 +59,7 @@ where
         LayerManifest::test_default()
     }
 
-    fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+    fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
         &self.global_hooks
     }
 

--- a/vulkan-layer/tests/integration_test.rs
+++ b/vulkan-layer/tests/integration_test.rs
@@ -222,7 +222,7 @@ mod get_instance_proc_addr {
                         let global: Global<TestLayer> = Default::default();
                         global
                             .layer_info
-                            .get_global_hooks()
+                            .global_hooks()
                             .expect_create_instance()
                             .once()
                             .return_const(LayerResult::Unhandled);
@@ -815,7 +815,7 @@ mod create_destroy_instance {
             let layer1_info = &TestLayer::<Tag<0>>::global_instance().layer_info;
             let layer2_info = &TestLayer::<Tag<1>>::global_instance().layer_info;
             {
-                let mut layer1_global_hooks = layer1_info.get_global_hooks();
+                let mut layer1_global_hooks = layer1_info.global_hooks();
                 layer1_global_hooks
                     .expect_create_instance()
                     .withf_st(match_create_instance(
@@ -826,7 +826,7 @@ mod create_destroy_instance {
                     .return_const(LayerResult::Unhandled);
             }
             {
-                let mut layer2_global_hooks = layer2_info.get_global_hooks();
+                let mut layer2_global_hooks = layer2_info.global_hooks();
                 layer2_global_hooks
                     .expect_create_instance()
                     .withf_st(match_create_instance(None, &icd_layer_link))
@@ -837,8 +837,8 @@ mod create_destroy_instance {
             let instance = vk::InstanceCreateInfo::builder()
                 .default_instance::<(TestLayer<Tag<0>>, TestLayer<Tag<1>>)>();
             {
-                layer1_info.get_global_hooks().checkpoint();
-                layer2_info.get_global_hooks().checkpoint();
+                layer1_info.global_hooks().checkpoint();
+                layer2_info.global_hooks().checkpoint();
             }
             drop(instance);
         }
@@ -920,7 +920,7 @@ mod create_destroy_instance {
         let mut instance = MaybeUninit::<vk::Instance>::uninit();
         TestLayer::<Tag<1>>::global_instance()
             .layer_info
-            .get_global_hooks()
+            .global_hooks()
             .expect_create_instance()
             .once()
             .withf_st({
@@ -2154,7 +2154,7 @@ fn global_should_be_trivially_destructible() {
             LayerManifest::test_default()
         }
 
-        fn get_global_hooks_info(&self) -> &Self::GlobalHooksInfo {
+        fn global_hooks_info(&self) -> &Self::GlobalHooksInfo {
             &self.0
         }
 

--- a/vulkan-layer/tests/integration_test.rs
+++ b/vulkan-layer/tests/integration_test.rs
@@ -2109,13 +2109,12 @@ fn enumerate_instance_layer_properties_should_return_correct_properties() {
     assert_eq!(property_count, 1);
     let property = unsafe { property.assume_init() };
 
-    let property_layer_name = unsafe { CStr::from_ptr(property.layer_name.as_ptr() as *const i8) }
+    let property_layer_name = unsafe { CStr::from_ptr(property.layer_name.as_ptr()) }
         .to_str()
         .unwrap();
-    let property_description =
-        unsafe { CStr::from_ptr(property.description.as_ptr() as *const i8) }
-            .to_str()
-            .unwrap();
+    let property_description = unsafe { CStr::from_ptr(property.description.as_ptr()) }
+        .to_str()
+        .unwrap();
     assert_eq!(property_layer_name, LAYER_MANIFEST.name);
     assert_eq!(property.spec_version, LAYER_MANIFEST.spec_version);
     assert_eq!(


### PR DESCRIPTION
* Rename `get_global_hooks_info` to `global_hooks_info`
* Fix the behavior of `vkEnumerateDeviceExtensionProperties` to call into the next chain if layer name doesn't match.
* Clean up TODOs and contributing document to include more about documentation, CI and tests.