### PR TITLE
Bump the version of some github actions

### DIFF
--- a/.github/workflows/postsubmit-miri.yml
+++ b/.github/workflows/postsubmit-miri.yml
@@ -25,7 +25,7 @@ jobs:
     # generally faster.
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up nightly Rust toolchain
         # dtolnay/rust-toolchain@nightly
         uses: dtolnay/rust-toolchain@f2f3c4b315c5bb8415dbb043af44ec90f68ae503

--- a/.github/workflows/postsubmit.yml
+++ b/.github/workflows/postsubmit.yml
@@ -25,7 +25,7 @@ jobs:
     needs: run_presubmit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: static_resource
       - run: rm -rf coverage-Linux

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -28,7 +28,7 @@ jobs:
         os: ["ubuntu-latest", "windows-latest"]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup LLVM install path
@@ -97,7 +97,7 @@ jobs:
         run: go install github.com/google/addlicense@master
       - run: cargo make ci-presubmit
       - name: Checkout base coverage
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: static_resource
           sparse-checkout: |
@@ -107,7 +107,7 @@ jobs:
       - name: Report coverage
         # 06393993/lcov-reporter-action@master
         # TODO: once the upstream accept the PR, change back to romeovs/lcov-reporter-action@master
-        uses: 06393993/lcov-reporter-action@45b31bf53fa5ac82d0f49039198080afdb535288
+        uses: 06393993/lcov-reporter-action@24d48ff28930b87e67d0df34283153b04a76f166
         with:
           lcov-file: target/lcov.info
           lcov-base: ${{ format('target/base-coverage/coverage-{0}/lcov.info', runner.os) }}


### PR DESCRIPTION
... so that every action is using the node20 runtime and we don't rely on the node16 runtime that is being deprecated.

* lcov-reporter-action
* actions/checkout