### PR TITLE
Fix postsubmit error

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -113,7 +113,7 @@ jobs:
           lcov-base: ${{ format('target/base-coverage/coverage-{0}/lcov.info', runner.os) }}
           filter-changed-files: true
           title: ${{ format('Test coverage for {0}', runner.os) }}
-          post-to: ${{ github.event_name == 'push' && 'comment' || 'job-summary' }}
+          post-to: job-summary
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ format('coverage-{0}', runner.os) }}


### PR DESCRIPTION
The postsubmit doesn't have the permission to post a comment, so change to post the coverage report to the job summary instead.