### PR TITLE
Bump Swatinem/rust-cache to 2.7.8

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -74,8 +74,8 @@ jobs:
           components: rustfmt
       - run: rustup default stable
       - name: Set up Rust dependency cache
-        # Swatinem/rust-cache@master
-        uses: Swatinem/rust-cache@9bdad043e88c75890e36ad3bbc8d27f0090dd609
+        # Swatinem/rust-cache@2.7.8
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6
         with:
           key: ${{ runner.os }}
           cache-all-crates: true


### PR DESCRIPTION
... which supports the new version of Cargo.lock.